### PR TITLE
Add resizable workbench layout

### DIFF
--- a/app/(writer)/page.tsx
+++ b/app/(writer)/page.tsx
@@ -1,0 +1,58 @@
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+
+import { AppSidebar } from '@/components/app-sidebar';
+import { Chat } from '@/components/chat';
+import { DataStreamHandler } from '@/components/data-stream-handler';
+import { WorkbenchLayout } from '@/components/workbench-layout';
+import { SidebarProvider } from '@/components/ui/sidebar';
+import { DEFAULT_CHAT_MODEL } from '@/lib/ai/models';
+import { auth } from '../(auth)/auth';
+import { generateUUID } from '@/lib/utils';
+import { Editor } from '@/components/text-editor';
+
+export default async function Page() {
+  const session = await auth();
+
+  if (!session) {
+    redirect('/api/auth/guest');
+  }
+
+  const id = generateUUID();
+  const cookieStore = await cookies();
+  const modelIdFromCookie = cookieStore.get('chat-model');
+  const initialModel = modelIdFromCookie?.value ?? DEFAULT_CHAT_MODEL;
+
+  return (
+    <SidebarProvider defaultOpen={true}>
+      <WorkbenchLayout
+        sidebar={<AppSidebar user={session.user} />}
+        editor={
+          <Editor
+            content=""
+            suggestions={[]}
+            isCurrentVersion={true}
+            currentVersionIndex={0}
+            status="idle"
+            onSaveContent={() => {}}
+          />
+        }
+        chat={
+          <>
+            <Chat
+              key={id}
+              id={id}
+              initialMessages={[]}
+              initialChatModel={initialModel}
+              initialVisibilityType="private"
+              isReadonly={false}
+              session={session}
+              autoResume={false}
+            />
+            <DataStreamHandler id={id} />
+          </>
+        }
+      />
+    </SidebarProvider>
+  );
+}

--- a/components/workbench-layout.tsx
+++ b/components/workbench-layout.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import { ReactNode } from 'react';
+import { PanelGroup, Panel, PanelResizeHandle } from 'react-resizable-panels';
+
+import { cn } from '@/lib/utils';
+import { useIsMobile } from '@/hooks/use-mobile';
+
+interface WorkbenchLayoutProps {
+  sidebar: ReactNode;
+  editor: ReactNode;
+  chat: ReactNode;
+}
+
+export function WorkbenchLayout({ sidebar, editor, chat }: WorkbenchLayoutProps) {
+  const isMobile = useIsMobile();
+
+  return (
+    <div className="h-dvh w-full flex">
+      <PanelGroup direction="horizontal" className="flex w-full h-full">
+        <Panel
+          defaultSize={isMobile ? 0 : 20}
+          minSize={15}
+          collapsedSize={0}
+          collapsible
+          className={cn('border-r bg-sidebar overflow-y-auto', isMobile && 'hidden')}
+        >
+          {sidebar}
+        </Panel>
+        <PanelResizeHandle className="w-1 bg-border cursor-col-resize" />
+        <Panel
+          defaultSize={isMobile ? 100 : 60}
+          minSize={20}
+          className="overflow-y-auto"
+        >
+          {editor}
+        </Panel>
+        <PanelResizeHandle className={cn('w-1 bg-border cursor-col-resize', isMobile && 'hidden')} />
+        <Panel
+          defaultSize={isMobile ? 0 : 20}
+          minSize={15}
+          collapsedSize={0}
+          collapsible
+          className={cn('border-l overflow-y-auto', isMobile && 'hidden')}
+        >
+          {chat}
+        </Panel>
+      </PanelGroup>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `WorkbenchLayout` component using `react-resizable-panels`
- create `(writer)` route implementing the new layout with sidebar, editors, and chat

## Testing
- `pnpm lint` *(fails: `EHOSTUNREACH` while trying to fetch pnpm package)*