### PR TITLE
Add PDF/DOCX export

### DIFF
--- a/app/api/export/docx/route.ts
+++ b/app/api/export/docx/route.ts
@@ -1,0 +1,28 @@
+import { Document, Packer, Paragraph } from 'docx';
+
+export async function POST(request: Request) {
+  try {
+    const { content } = await request.json();
+    const doc = new Document({
+      sections: [
+        {
+          children: String(content)
+            .split('\n')
+            .map((line) => new Paragraph(line.replace(/[\*#_`]/g, ''))),
+        },
+      ],
+    });
+
+    const buffer = await Packer.toBuffer(doc);
+
+    return new Response(buffer, {
+      headers: {
+        'Content-Type':
+          'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        'Content-Disposition': 'attachment; filename="export.docx"',
+      },
+    });
+  } catch (error) {
+    return new Response('Bad Request', { status: 400 });
+  }
+}

--- a/app/api/export/pdf/route.ts
+++ b/app/api/export/pdf/route.ts
@@ -1,0 +1,31 @@
+import { PDFDocument, StandardFonts } from 'pdf-lib';
+
+export async function POST(request: Request) {
+  try {
+    const { content } = await request.json();
+    const pdfDoc = await PDFDocument.create();
+    let page = pdfDoc.addPage();
+    const font = await pdfDoc.embedFont(StandardFonts.Helvetica);
+    const { width, height } = page.getSize();
+    const fontSize = 12;
+    const lines = String(content).replace(/[\*#_`]/g, '').split('\n');
+    let y = height - fontSize * 2;
+    for (const line of lines) {
+      page.drawText(line, { x: 50, y, size: fontSize, font });
+      y -= fontSize + 4;
+      if (y < 50) {
+        y = height - fontSize * 2;
+        page = pdfDoc.addPage();
+      }
+    }
+    const pdfBytes = await pdfDoc.save();
+    return new Response(pdfBytes, {
+      headers: {
+        'Content-Type': 'application/pdf',
+        'Content-Disposition': 'attachment; filename="export.pdf"',
+      },
+    });
+  } catch (error) {
+    return new Response('Bad Request', { status: 400 });
+  }
+}

--- a/components/text-editor.tsx
+++ b/components/text-editor.tsx
@@ -5,6 +5,8 @@ import { inputRules } from 'prosemirror-inputrules';
 import { EditorState } from 'prosemirror-state';
 import { EditorView } from 'prosemirror-view';
 import React, { memo, useEffect, useRef } from 'react';
+import { Button } from './ui/button';
+import { toast } from 'sonner';
 
 import type { Suggestion } from '@/lib/db/schema';
 import {
@@ -145,8 +147,44 @@ function PureEditor({
     }
   }, [suggestions, content]);
 
+  const handleExport = async (type: 'pdf' | 'docx') => {
+    try {
+      const response = await fetch(`/api/export/${type}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content }),
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to export');
+      }
+
+      const blob = await response.blob();
+      const url = window.URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `document.${type === 'pdf' ? 'pdf' : 'docx'}`;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      window.URL.revokeObjectURL(url);
+    } catch (error) {
+      toast.error('Failed to export');
+    }
+  };
+
   return (
-    <div className="relative prose dark:prose-invert" ref={containerRef} />
+    <div>
+      <div className="relative prose dark:prose-invert" ref={containerRef} />
+      <div className="mt-2 flex gap-2">
+        <Button variant="outline" onClick={() => handleExport('pdf')}>
+          Export as PDF
+        </Button>
+        <Button variant="outline" onClick={() => handleExport('docx')}>
+          Export as DOCX
+        </Button>
+      </div>
+    </div>
   );
 }
 

--- a/package.json
+++ b/package.json
@@ -83,6 +83,8 @@
     "server-only": "^0.0.1",
     "sonner": "^1.5.0",
     "swr": "^2.2.5",
+    "pdf-lib": "^1.17.1",
+    "docx": "^8.0.3",
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
     "usehooks-ts": "^3.1.0",


### PR DESCRIPTION
## Summary
- add buttons to export document as PDF or DOCX
- add `/api/export/pdf` and `/api/export/docx` routes
- generate simple PDF and DOCX files server-side
- include `pdf-lib` and `docx` in dependencies

## Testing
- `pnpm test` *(fails: EHOSTUNREACH)*