### PR TITLE
Add writer documents listing

### DIFF
--- a/app/(chat)/api/document/route.ts
+++ b/app/(chat)/api/document/route.ts
@@ -3,6 +3,7 @@ import type { ArtifactKind } from '@/components/artifact';
 import {
   deleteDocumentsByIdAfterTimestamp,
   getDocumentsById,
+  getDocumentsByUserId,
   saveDocument,
 } from '@/lib/db/queries';
 import { ChatSDKError } from '@/lib/errors';
@@ -11,17 +12,15 @@ export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const id = searchParams.get('id');
 
-  if (!id) {
-    return new ChatSDKError(
-      'bad_request:api',
-      'Parameter id is missing',
-    ).toResponse();
-  }
-
   const session = await auth();
 
   if (!session?.user) {
     return new ChatSDKError('unauthorized:document').toResponse();
+  }
+
+  if (!id) {
+    const documents = await getDocumentsByUserId({ id: session.user.id });
+    return Response.json(documents, { status: 200 });
   }
 
   const documents = await getDocumentsById({ id });

--- a/app/(writer)/documents/page.tsx
+++ b/app/(writer)/documents/page.tsx
@@ -1,0 +1,65 @@
+import { auth } from '@/app/(auth)/auth';
+import { redirect } from 'next/navigation';
+import { DocumentPreview } from '@/components/document-preview';
+import type { Document } from '@/lib/db/schema';
+import Link from 'next/link';
+
+export default async function Page() {
+  const session = await auth();
+
+  if (!session) {
+    redirect('/api/auth/guest');
+  }
+
+  const res = await fetch('http://localhost:3000/api/document', {
+    cache: 'no-store',
+  });
+
+  if (!res.ok) {
+    throw new Error('Failed to fetch documents');
+  }
+
+  const documents: Array<Document> = await res.json();
+
+  return (
+    <div className="p-4 space-y-6">
+      <h1 className="text-2xl font-semibold">Your Documents</h1>
+      {documents.length === 0 ? (
+        <p className="text-muted-foreground">No documents found.</p>
+      ) : (
+        <div className="space-y-6">
+          {documents.map((doc) => (
+            <div
+              key={`${doc.id}-${doc.createdAt}`}
+              className="border rounded-lg p-4 space-y-2"
+            >
+              <div className="flex justify-between items-start">
+                <div>
+                  <div className="font-medium">{doc.title}</div>
+                  <div className="text-sm text-muted-foreground">
+                    {new Date(doc.createdAt).toLocaleString()}
+                  </div>
+                </div>
+                <div className="flex gap-2 text-sm">
+                  <Link href="/writer" className="underline">
+                    Open
+                  </Link>
+                  <button className="underline" disabled>
+                    Rename
+                  </button>
+                  <button className="underline" disabled>
+                    Delete
+                  </button>
+                </div>
+              </div>
+              <DocumentPreview
+                isReadonly={false}
+                result={{ id: doc.id, title: doc.title, kind: doc.kind }}
+              />
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/lib/db/queries.ts
+++ b/lib/db/queries.ts
@@ -324,6 +324,21 @@ export async function getDocumentsById({ id }: { id: string }) {
   }
 }
 
+export async function getDocumentsByUserId({ id }: { id: string }) {
+  try {
+    return await db
+      .select()
+      .from(document)
+      .where(eq(document.userId, id))
+      .orderBy(desc(document.createdAt));
+  } catch (error) {
+    throw new ChatSDKError(
+      'bad_request:database',
+      'Failed to get documents by user id',
+    );
+  }
+}
+
 export async function getDocumentById({ id }: { id: string }) {
   try {
     const [selectedDocument] = await db

--- a/tests/routes/document.test.ts
+++ b/tests/routes/document.test.ts
@@ -7,15 +7,14 @@ const documentsCreatedByAda: Array<Document> = [];
 
 test.describe
   .serial('/api/document', () => {
-    test('Ada cannot retrieve a document without specifying an id', async ({
+    test('Ada can retrieve all documents without specifying an id', async ({
       adaContext,
     }) => {
       const response = await adaContext.request.get('/api/document');
-      expect(response.status()).toBe(400);
+      expect(response.status()).toBe(200);
 
-      const { code, message } = await response.json();
-      expect(code).toEqual('bad_request:api');
-      expect(message).toEqual(getMessageByErrorCode(code));
+      const documents = await response.json();
+      expect(documents).toEqual([]);
     });
 
     test('Ada cannot retrieve a document that does not exist', async ({


### PR DESCRIPTION
## Summary
- support retrieving all documents by user in DB queries and API
- list user documents on `/writer/documents`
- adjust document API test for new behavior

## Testing
- `pnpm test` *(fails: EHOSTUNREACH while installing pnpm)*