### PR TITLE
Add document outline sidebar

### DIFF
--- a/app/(writer)/page.tsx
+++ b/app/(writer)/page.tsx
@@ -1,15 +1,11 @@
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 
-import { AppSidebar } from '@/components/app-sidebar';
-import { Chat } from '@/components/chat';
-import { DataStreamHandler } from '@/components/data-stream-handler';
-import { WorkbenchLayout } from '@/components/workbench-layout';
 import { SidebarProvider } from '@/components/ui/sidebar';
 import { DEFAULT_CHAT_MODEL } from '@/lib/ai/models';
 import { auth } from '../(auth)/auth';
 import { generateUUID } from '@/lib/utils';
-import { Editor } from '@/components/text-editor';
+import { WriterClient } from '@/components/writer-client';
 
 export default async function Page() {
   const session = await auth();
@@ -25,34 +21,7 @@ export default async function Page() {
 
   return (
     <SidebarProvider defaultOpen={true}>
-      <WorkbenchLayout
-        sidebar={<AppSidebar user={session.user} />}
-        editor={
-          <Editor
-            content=""
-            suggestions={[]}
-            isCurrentVersion={true}
-            currentVersionIndex={0}
-            status="idle"
-            onSaveContent={() => {}}
-          />
-        }
-        chat={
-          <>
-            <Chat
-              key={id}
-              id={id}
-              initialMessages={[]}
-              initialChatModel={initialModel}
-              initialVisibilityType="private"
-              isReadonly={false}
-              session={session}
-              autoResume={false}
-            />
-            <DataStreamHandler id={id} />
-          </>
-        }
-      />
+      <WriterClient session={session} chatId={id} initialModel={initialModel} />
     </SidebarProvider>
   );
 }

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { ReactNode } from 'react';
 import type { User } from 'next-auth';
 import { useRouter } from 'next/navigation';
 
@@ -18,7 +19,13 @@ import {
 import Link from 'next/link';
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
 
-export function AppSidebar({ user }: { user: User | undefined }) {
+export function AppSidebar({
+  user,
+  extraContent,
+}: {
+  user: User | undefined;
+  extraContent?: ReactNode;
+}) {
   const router = useRouter();
   const { setOpenMobile } = useSidebar();
 
@@ -60,6 +67,7 @@ export function AppSidebar({ user }: { user: User | undefined }) {
       </SidebarHeader>
       <SidebarContent>
         <SidebarHistory user={user} />
+        {extraContent}
       </SidebarContent>
       <SidebarFooter>{user && <SidebarUserNav user={user} />}</SidebarFooter>
     </Sidebar>

--- a/components/document-outline.tsx
+++ b/components/document-outline.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarMenu,
+  SidebarMenuItem,
+  SidebarMenuButton,
+} from './ui/sidebar';
+import type { Heading } from '@/lib/editor/functions';
+import { ChevronDownIcon } from './icons';
+
+interface DocumentOutlineProps {
+  outline: Heading[];
+  onSelect: (heading: Heading) => void;
+}
+
+export function DocumentOutline({ outline, onSelect }: DocumentOutlineProps) {
+  const [open, setOpen] = useState(true);
+
+  if (outline.length === 0) return null;
+
+  return (
+    <SidebarGroup className="border-t" data-testid="document-outline">
+      <div className="flex items-center justify-between">
+        <SidebarGroupLabel className="cursor-pointer select-none" onClick={() => setOpen(!open)}>
+          Outline
+        </SidebarGroupLabel>
+        <button onClick={() => setOpen(!open)} className="p-1" aria-label="Toggle outline">
+          <ChevronDownIcon size={12} style={{ transform: open ? 'rotate(0deg)' : 'rotate(-90deg)' }} />
+        </button>
+      </div>
+      {open && (
+        <SidebarGroupContent>
+          <SidebarMenu>
+            {outline.map((item, idx) => (
+              <SidebarMenuItem key={idx} style={{ paddingLeft: (item.level - 1) * 8 }}>
+                <SidebarMenuButton asChild>
+                  <button className="truncate w-full text-left" onClick={() => onSelect(item)}>
+                    {item.text || 'Untitled'}
+                  </button>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            ))}
+          </SidebarMenu>
+        </SidebarGroupContent>
+      )}
+    </SidebarGroup>
+  );
+}

--- a/components/text-editor.tsx
+++ b/components/text-editor.tsx
@@ -16,6 +16,8 @@ import {
   buildContentFromDocument,
   buildDocumentFromContent,
   createDecorations,
+  extractHeadings,
+  type Heading,
 } from '@/lib/editor/functions';
 import {
   projectWithPositions,
@@ -30,6 +32,8 @@ type EditorProps = {
   isCurrentVersion: boolean;
   currentVersionIndex: number;
   suggestions: Array<Suggestion>;
+  onHeadingsChange?: (headings: Heading[]) => void;
+  editorViewRef?: React.MutableRefObject<EditorView | null>;
 };
 
 function PureEditor({
@@ -37,6 +41,8 @@ function PureEditor({
   onSaveContent,
   suggestions,
   status,
+  onHeadingsChange,
+  editorViewRef,
 }: EditorProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const editorRef = useRef<EditorView | null>(null);
@@ -64,12 +70,21 @@ function PureEditor({
       editorRef.current = new EditorView(containerRef.current, {
         state,
       });
+      if (editorViewRef) {
+        editorViewRef.current = editorRef.current;
+      }
+      if (onHeadingsChange) {
+        onHeadingsChange(extractHeadings(state.doc));
+      }
     }
 
     return () => {
       if (editorRef.current) {
         editorRef.current.destroy();
         editorRef.current = null;
+        if (editorViewRef) {
+          editorViewRef.current = null;
+        }
       }
     };
     // NOTE: we only want to run this effect once
@@ -84,6 +99,7 @@ function PureEditor({
             transaction,
             editorRef,
             onSaveContent,
+            onHeadingsChange,
           });
         },
       });
@@ -107,6 +123,9 @@ function PureEditor({
 
         transaction.setMeta('no-save', true);
         editorRef.current.dispatch(transaction);
+        if (onHeadingsChange) {
+          onHeadingsChange(extractHeadings(editorRef.current.state.doc));
+        }
         return;
       }
 
@@ -121,6 +140,9 @@ function PureEditor({
 
         transaction.setMeta('no-save', true);
         editorRef.current.dispatch(transaction);
+        if (onHeadingsChange) {
+          onHeadingsChange(extractHeadings(editorRef.current.state.doc));
+        }
       }
     }
   }, [content, status]);
@@ -157,7 +179,9 @@ function areEqual(prevProps: EditorProps, nextProps: EditorProps) {
     prevProps.isCurrentVersion === nextProps.isCurrentVersion &&
     !(prevProps.status === 'streaming' && nextProps.status === 'streaming') &&
     prevProps.content === nextProps.content &&
-    prevProps.onSaveContent === nextProps.onSaveContent
+    prevProps.onSaveContent === nextProps.onSaveContent &&
+    prevProps.onHeadingsChange === nextProps.onHeadingsChange &&
+    prevProps.editorViewRef === nextProps.editorViewRef
   );
 }
 

--- a/components/writer-client.tsx
+++ b/components/writer-client.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import type { Session } from 'next-auth';
+import type { EditorView } from 'prosemirror-view';
+
+import { WorkbenchLayout } from './workbench-layout';
+import { AppSidebar } from './app-sidebar';
+import { Chat } from './chat';
+import { DataStreamHandler } from './data-stream-handler';
+import { Editor } from './text-editor';
+import { DocumentOutline } from './document-outline';
+import type { Heading } from '@/lib/editor/functions';
+
+interface WriterClientProps {
+  session: Session;
+  chatId: string;
+  initialModel: string;
+}
+
+export function WriterClient({ session, chatId, initialModel }: WriterClientProps) {
+  const [outline, setOutline] = useState<Heading[]>([]);
+  const editorViewRef = useRef<EditorView | null>(null);
+
+  const handleSelect = (heading: Heading) => {
+    const view = editorViewRef.current;
+    if (!view) return;
+    const dom = view.nodeDOM(heading.pos) as HTMLElement | null;
+    dom?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  };
+
+  return (
+    <WorkbenchLayout
+      sidebar={
+        <AppSidebar
+          user={session.user}
+          extraContent={<DocumentOutline outline={outline} onSelect={handleSelect} />}
+        />
+      }
+      editor={
+        <Editor
+          content=""
+          suggestions={[]}
+          isCurrentVersion={true}
+          currentVersionIndex={0}
+          status="idle"
+          onSaveContent={() => {}}
+          onHeadingsChange={setOutline}
+          editorViewRef={editorViewRef}
+        />
+      }
+      chat={
+        <>
+          <Chat
+            key={chatId}
+            id={chatId}
+            initialMessages={[]}
+            initialChatModel={initialModel}
+            initialVisibilityType="private"
+            isReadonly={false}
+            session={session}
+            autoResume={false}
+          />
+          <DataStreamHandler id={chatId} />
+        </>
+      }
+    />
+  );
+}

--- a/lib/editor/config.ts
+++ b/lib/editor/config.ts
@@ -6,7 +6,7 @@ import type { Transaction } from 'prosemirror-state';
 import type { EditorView } from 'prosemirror-view';
 import type { MutableRefObject } from 'react';
 
-import { buildContentFromDocument } from './functions';
+import { buildContentFromDocument, extractHeadings, type Heading } from './functions';
 
 export const documentSchema = new Schema({
   nodes: addListNodes(schema.spec.nodes, 'paragraph block*', 'block'),
@@ -25,15 +25,21 @@ export const handleTransaction = ({
   transaction,
   editorRef,
   onSaveContent,
+  onHeadingsChange,
 }: {
   transaction: Transaction;
   editorRef: MutableRefObject<EditorView | null>;
   onSaveContent: (updatedContent: string, debounce: boolean) => void;
+  onHeadingsChange?: (headings: Heading[]) => void;
 }) => {
   if (!editorRef || !editorRef.current) return;
 
   const newState = editorRef.current.state.apply(transaction);
   editorRef.current.updateState(newState);
+
+  if (onHeadingsChange) {
+    onHeadingsChange(extractHeadings(newState.doc));
+  }
 
   if (transaction.docChanged && !transaction.getMeta('no-save')) {
     const updatedContent = buildContentFromDocument(newState.doc);

--- a/lib/editor/functions.tsx
+++ b/lib/editor/functions.tsx
@@ -60,3 +60,23 @@ export const createDecorations = (
 
   return DecorationSet.create(view.state.doc, decorations);
 };
+
+export type Heading = {
+  level: number;
+  text: string;
+  pos: number;
+};
+
+export const extractHeadings = (doc: Node): Heading[] => {
+  const headings: Heading[] = [];
+  doc.descendants((node, pos) => {
+    if (node.type.name === 'heading') {
+      headings.push({
+        level: node.attrs.level,
+        text: node.textContent,
+        pos,
+      });
+    }
+  });
+  return headings;
+};


### PR DESCRIPTION
## Summary
- parse headings from ProseMirror documents
- display a collapsible outline sidebar with links to headings
- keep track of outline in the writer page
- scroll editor when an outline item is clicked

## Testing
- `pnpm lint` *(fails: connect EHOSTUNREACH)*
- `pnpm test` *(fails: connect EHOSTUNREACH)*